### PR TITLE
Add package libffi-dev, needed for Ruby 2.2.*

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -11,3 +11,4 @@ apt_repository("node.js") do
   key "C7917B12"
 end
 package 'nodejs'
+package 'libffi-dev' # needed for Ruby 2.2.* to be installed by rbenv


### PR DESCRIPTION
Ruby 2.2.\* fails compilation unless libffi-dev is installed first.  I'm not sure if this is the right place to put that package command, but since rails_gem_dependencies-tlq is executed before the rbenv cookbook, installing the package here allows Ruby 2.2.\* to install.
